### PR TITLE
Changes URL to fetch br-atlas data from

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -62,7 +62,7 @@
   };
   section.hide();
 
-  var baseUrl = 'http://sandbox.israelst.com/br-atlas/geo/';
+  var baseUrl = 'https://estacoes.dengue.mat.br/br-atlas/geo/';
   var urlStations = 'https://raw.githubusercontent.com/AlertaDengue/AlertaDengueCaptura/master/utilities/stations/stations_seed.csv';
 
   var width = document.body.clientWidth,


### PR DESCRIPTION
I used the complete url instead of a relative path because the data is
not being provided by this service, even tough it will probably be
served from the same webserver.

With this change we will be able to start using SSL in estacoes.dengue.mat.br.

@israelst please review and merge so I can deploy :)
