### PR TITLE
Uses ubuntu as a base for the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM ubuntu
 
 RUN apt-get update
 


### PR DESCRIPTION
Debian stable doesn't include the npm package (even though sid does).
Since ubuntu is running in the host anyways and it inlcudes npm, we can
use it here.